### PR TITLE
Resource file inclusion fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,15 @@
 	</distributionManagement>
 	
 	<build>
-		<plugins>
+      <resources>
+        <resource>
+          <directory>${basedir}/src/main/java</directory>
+          <excludes>
+            <exclude>**/*.java</exclude>
+          </excludes>
+        </resource>
+      </resources>
+	    <plugins>
 			 <plugin>
 				<groupId>org.codehaus.mojo</groupId>
 				<artifactId>gwt-maven-plugin</artifactId>


### PR DESCRIPTION
Include any non-.java files under src/ as resources in the jar file. Needed for the gwt xml files that reside in the src/ dir.
